### PR TITLE
azure-mgmt-authorization and azure-cli updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ with open("vFXT/version.py") as f:
     exec(f.read(), version) #pylint: disable=exec-used
 
 base_deps = ['future', 'requests']
-azure_deps = ['requests-oauthlib', 'adal==1.2.7', 'azure-cli-core==2.39.0', 'azure-common==1.1.28', 'azure-mgmt-authorization==2.0.0', 'azure-mgmt-compute==27.1.0', 'azure-identity==1.10.0', 'azure-mgmt-msi==6.0.1', 'azure-mgmt-network==20.0.0', 'azure-mgmt-resource==21.1.0b1', 'azure-mgmt-storage==20.0.0', 'azure-storage-blob==12.11.0', 'azure-storage-queue==12.2.0', 'azure-storage-common==2.1.0', 'knack==0.9.0', 'msrest==0.7.1', 'msrestazure==0.6.4']
+# Add azure-cli installation here when this GitHub issue is resolved: https://github.com/Azure/azure-cli/issues/23372
+azure_deps = ['requests-oauthlib', 'adal==1.2.7', 'azure-cli-core==2.43.0', 'azure-common==1.1.28', 'azure-mgmt-authorization==3.0.0', 'azure-mgmt-compute==29.0.0', 'azure-identity==1.10.0', 'azure-mgmt-msi==6.1.0', 'azure-mgmt-network==21.0.1', 'azure-mgmt-resource==21.1.0b1', 'azure-mgmt-storage==21.0.0', 'azure-storage-blob==12.11.0', 'azure-storage-queue==12.2.0', 'azure-storage-common==1.4', 'knack==0.10.1', 'msrest==0.7.1', 'msrestazure==0.6.4']
 
 setup(name='vFXT',
     version=version['__version__'],

--- a/vFXT/cluster.py
+++ b/vFXT/cluster.py
@@ -1321,8 +1321,7 @@ class Cluster(object): #pylint: disable=useless-object-inheritance
                 proxy (str, optional): proxy configuration to use
 
                 type (str, optional): type of corefiler (default 'cloud')
-                cloud_type (str, optional): cloud type (default 's3')
-                s3_type (str, optional): S3 type (default Service.S3TYPE_NAME)
+                cloud_type (str, optional): cloud type (azure)
                 https (str, optional): 'yes' or 'no' to use HTTPS (default 'yes')
                 crypto_mode (str, optional): crypto mode (default CBC-AES-256-HMAC-SHA-512)
                 compress_mode (str, optional): compression mode (default LZ4)

--- a/vFXT/msazure.py
+++ b/vFXT/msazure.py
@@ -2255,7 +2255,7 @@ class Service(ServiceBase):
 
         try:
             storage_account_props = self.connection('storage').storage_accounts.get_properties(self.storage_resource_group, storage_account)
-            if storage_account_props.sku.tier.lower()== 'premium':
+            if storage_account_props.sku.tier.lower() == 'premium':
                 raise Exception("Premium tier storage accounts are not supported")
 
             log.debug("storage account type {}".format(storage_account_props.sku.name))
@@ -2957,7 +2957,6 @@ class Service(ServiceBase):
                 if principal in [_.principal_id for _ in assignments]:
                     log.debug("Assignment for role {} and principal {} exists.".format(role.role_name, principal))
                     return None
-
                 body = {
                         'role_definition_id': role.id,
                         'principal_id': principal

--- a/vFXT/msazure.py
+++ b/vFXT/msazure.py
@@ -90,8 +90,7 @@ logging.getLogger('requests_oauthlib.oauth2_session').setLevel(logging.CRITICAL)
 logging.getLogger('msrestazure.azure_active_directory').setLevel(logging.CRITICAL)
 logging.getLogger('keyring.backend').setLevel(logging.CRITICAL)
 
-import azure.identity
-from azure.identity import AzureCliCredential
+from azure.identity import DefaultAzureCredential
 import azure.storage.blob
 import azure.storage.common
 import azure.common.client_factory
@@ -377,14 +376,14 @@ class Service(ServiceBase):
 
         return True
     @staticmethod
-    def fetch_subscription_for_resource_group(res_grp=None):
+    def fetch_subscription_for_resource_group(res_grp=None, cred=None):
         """
         Input  : Name of resource group or None
         Output : First subscription which contains the resource group or
                  First subscription if input is None
         Returns an object of type azure.mgmt.resource.subscriptions
         """
-        cred = AzureCliCredential()
+        cred = cred or DefaultAzureCredential()
         newconn = SubscriptionClient(cred)
         subs_list = newconn.subscriptions.list()
         if not res_grp:
@@ -477,7 +476,7 @@ class Service(ServiceBase):
 
         default_api_version = None
         connection_types = {
-            'authorization': {'cls': azure.mgmt.authorization.AuthorizationManagementClient, 'pass_subscription': True, 'api_version': '2018-01-01-preview'},
+            'authorization': {'cls': azure.mgmt.authorization.AuthorizationManagementClient, 'pass_subscription': True, 'api_version': '2022-04-01'},
             'blobstorage': None, # special handling below
             'compute': {'cls': azure.mgmt.compute.ComputeManagementClient, 'pass_subscription': True, 'api_version': default_api_version},
             'identity': {'cls': azure.mgmt.msi.ManagedServiceIdentityClient, 'pass_subscription': True, 'api_version': default_api_version},
@@ -503,31 +502,32 @@ class Service(ServiceBase):
             if connection_type == 'blobstorage':
                 storage_account = options.get('storage_account') or self.storage_account
                 resource_group = options.get('resource_group') or self.storage_resource_group
-                credential = None
-                if self.on_instance: # use MSI for auth
-                    credential = azure.identity.ManagedIdentityCredential()
-                else:
-                    try:
-                        keys = self.connection('storage').storage_accounts.list_keys(resource_group, storage_account).keys
-                        if not keys:
-                            raise Exception()
-                    except Exception:
-                        raise vFXTConfigurationException("Unable to look up storage keys for {}".format(storage_account))
-                    credential = keys[0].value # just use the first one, may be multiple
+                try:
+                    keys = self.connection('storage').storage_accounts.list_keys(resource_group, storage_account).keys
+                    if not keys:
+                        raise Exception()
+                except Exception:
+                    raise vFXTConfigurationException("Unable to look up storage keys for {}".format(storage_account))
+                credential = keys[0].value # just use the first one, may be multiple
                 blob_host = 'blob.{}'.format(self.storage_suffix) if self.storage_suffix else self.BLOB_HOST
                 storage_uri = 'https://{}.{}'.format(storage_account, blob_host)
                 return azure.storage.blob.BlobServiceClient(storage_uri, credential=credential)
 
             connection_settings = connection_types[connection_type]
             connection_cls = connection_settings['cls']
+
+            # if not run with on-instance, exclude managed identity as a valid auth method
+            # managed identity gets tried before environment or azure-cli credentials and, if there is ANY
+            # identity assigned (such as an azsecpack uami), it'll get picked up and used (against user intentions)
+            auth_kwargs = {"exclude_managed_identity_credential": True} if not self.on_instance else {}
+            cli_credential = DefaultAzureCredential(**auth_kwargs)
             if self.use_environment_for_auth:
                 # get_client_from_cli_profile seems racy, retry a few times
                 retries = 3
                 while True:
                     try:
-                        cli_credential = AzureCliCredential()
                         if not self.subscription_id:
-                            subscription_account = Service.fetch_subscription_for_resource_group(self.resource_group)
+                            subscription_account = Service.fetch_subscription_for_resource_group(self.resource_group, cred=cli_credential)
                             if subscription_account:
                                 self.subscription_id = subscription_account.subscription_id
                                 self.tenant_id = subscription_account.tenant_id
@@ -545,17 +545,6 @@ class Service(ServiceBase):
             else:
                 session = requests.sessions.Session()
                 session.proxies = proxies
-                cloud_environment = msrestazure.azure_cloud.get_cloud_from_metadata_endpoint(self.endpoint_base_url, session=session) if self.endpoint_base_url else None
-                if self.on_instance:
-                    if cloud_environment:
-                        creds = msrestazure.azure_active_directory.AADTokenCredentials(self.local.instance_data['access_token'], cloud_environment=cloud_environment)
-                    else:
-                        creds = msrestazure.azure_active_directory.AADTokenCredentials(self.local.instance_data['access_token'])
-                else:
-                    if cloud_environment:
-                        creds = azure.common.credentials.ServicePrincipalCredentials(self.application_id, self.application_secret, tenant=self.tenant_id, cloud_environment=cloud_environment)
-                    else:
-                        creds = azure.common.credentials.ServicePrincipalCredentials(self.application_id, self.application_secret, tenant=self.tenant_id)
 
                 connection_args = {}
                 if options.get('api_version'):
@@ -565,7 +554,7 @@ class Service(ServiceBase):
                 if connection_settings['pass_subscription']:
                     connection_args['subscription_id'] = self.subscription_id
 
-                newconn = connection_cls(creds, **connection_args)
+                newconn = connection_cls(cli_credential, **connection_args)
             # Add our proxy configuration, we do it here so we can support all cred types.
             # Some cred types support passing proxies, but some credential factories do
             # not support that mechanism
@@ -814,8 +803,10 @@ class Service(ServiceBase):
         '''
         options['use_environment_for_auth'] = True
         s = Service(**options)
+        # exclude managed identity credential so we pick up the credentials from the azure-cli instead
+        credential = DefaultAzureCredential(exclude_managed_identity_credential=True)
         if not s.subscription_id:
-            subscription_account = Service.fetch_subscription_for_resource_group(options['resource_group'])
+            subscription_account = Service.fetch_subscription_for_resource_group(options['resource_group'], cred=credential)
             if subscription_account:
                 s.subscription_id = subscription_account.subscription_id
                 s.tenant_id = subscription_account.tenant_id
@@ -1168,8 +1159,7 @@ class Service(ServiceBase):
         if not getattr(identity, 'principal_id', None):
             raise vFXTConfigurationException("Instance {} has no identity configuration".format(self.name(instance)))
 
-        principal_id = identity.principal_id
-        role_assignments = conn.role_assignments.list("principalId eq '{}'".format(principal_id))
+        role_assignments = conn.role_assignments.list_for_resource_group(self._instance_resource_group(instance))
         roles = [conn.role_definitions.get_by_id(_.role_definition_id) for _ in role_assignments]
         custom_roles = [_ for _ in roles if _.role_type == 'CustomRole']
         if custom_roles:
@@ -2933,7 +2923,7 @@ class Service(ServiceBase):
             raise vFXTConfigurationException("No such role: {}".format(role_name))
         try:
             # must delete assignments first
-            assignments = [_ for _ in conn.role_assignments.list() if role.id == _.role_definition_id]
+            assignments = conn.role_assignments.list_by_resource_group(self.resource_group)
             for assignment in assignments:
                 # this will fail if we do not have permissions
                 conn.role_assignments.begin_delete(assignment.scope, assignment.name)
@@ -2963,15 +2953,14 @@ class Service(ServiceBase):
             association_id = str(uuid.uuid4())
             try:
                 conn = self.connection('authorization')
-                assignments = [_ for _ in conn.role_assignments.list() if role.id == _.role_definition_id]
+                assignments = conn.role_assignments.list_for_resource_group(self.resource_group)
                 if principal in [_.principal_id for _ in assignments]:
                     log.debug("Assignment for role {} and principal {} exists.".format(role.role_name, principal))
                     return None
 
                 body = {
-                    'role_definition_id': role.id,
-                    'principal_id': principal,
-                    'principal_type': 'ServicePrincipal',
+                        'role_definition_id': role.id,
+                        'principal_id': principal
                 }
 
                 scope = self._resource_group_scope()

--- a/vFXT/version.py
+++ b/vFXT/version.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2020 Avere Systems, Inc.  All Rights Reserved.
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
-__version__ = "0.5.5.0"
-__version_info__ = (0, 5, 5, 0)
+__version__ = "0.5.5.1"
+__version_info__ = (0, 5, 5, 1)

--- a/vfxt.py
+++ b/vfxt.py
@@ -183,7 +183,7 @@ def main():
     action_opts.add_argument("--interact", help="Use the Python interpreter", action="store_true")
 
     # service arguments
-    parser.add_argument("--cloud-type", help="the cloud provider to use", choices=['azure'], required=True)
+    parser.add_argument("--cloud-type", help="the cloud provider to use", choices=['azure'], default='azure')
     parser.add_argument("--on-instance", help="Assume running on instance and query for instance credentials", action="store_true")
     parser.add_argument("--from-environment", help="Assume credentials from local configuration/environment", action="store_true")
     parser.add_argument("--image-id", help="Root disk image ID used to instantiate nodes")

--- a/vfxt.py
+++ b/vfxt.py
@@ -8,6 +8,7 @@ import argparse
 import base64
 import logging
 import getpass
+import os
 import ssl
 import sys
 import uuid
@@ -362,6 +363,13 @@ def main():
                 if not all([args.subscription_id, args.azure_network, args.azure_subnet, args.resource_group, args.location]):
                     logger.error("Arguments subscription-id, azure-network, azure-subnet, resource-group, and location are required")
                     parser.exit(1)
+
+
+                # set these env vars based on the credentials passed into vfxt.py
+                # DefaultAzureCredential will use them to create an EnvironmentCredential
+                os.environ['AZURE_TENANT_ID'] = args.tenant_id
+                os.environ['AZURE_CLIENT_ID'] = args.application_id
+                os.environ['AZURE_CLIENT_SECRET'] = args.application_secret
 
             opts = {
                 'subscription_id': args.subscription_id,


### PR DESCRIPTION
### Overview and Justification:

#### Commit 1: Use `azure-cli-core==2.43.0` and `azure-mgmt-authorization==3.0.0`
- **`azure-cli-core==2.43.0`:** Azure/Avere [needs 2.40.x](https://github.com/Azure/Avere/pull/1371). Might as well get as up to date as possible. 2.42.0 breaks `az network` commands.
- **`azure-mgmt-authorization==3.0.0`:** we need that for our own authorization in the Python SDK. 
- **SETUP.PY CHOICE: not installing the `azure-cli` in `setup.py`:** we need `azure-cli==2.43.0` to work with the corresponding `azure-cli-core`. The `azure-cli` depends on a way older version of `azure-mgmt-authorization` (0.61.x). `setup.py` couldn't cope with this dependency conflict. If you install `azure-cli` and `vFXT` separately, the install itself whines about dependency conflicts, but everything succeeds.
- **using `DefaultAzureCredential`:** if we don't use `DefaultAzureCredential`, we need to specify each individual type of cred (`EnvironmentCredential`, `AzureCliCredential`, and `MsiCredential`). That's annoying and bad.
- **excluding the managed identity credential when not run with `--on-instance`:** `DefaultAzureCredential` trial-and-errors creating credentials in a particular order and tries MSI first. If there is ANY identity assigned to a VM, it'll pick up on that. This can be misleading (and maybe break auth) if a user is trying to auth with a service principal or with the azure login credentials.
- **passing through creds to `fetch_subscription_for_resource_group`:** we kept creating creds multiple times for no reason

Also includes various small changes to accommodate the new version of `azure-cli-core`.

### Commit 2: Linting cleanup and removing errant `s3` reference
- we no longer use `s3`

### Commit 3: Make cloud-type default to `azure` in `vfxt.py`
- we only support `azure` now; we can simplify the `vfxt.py` command by eliminating the `cloud-type` arg requirement altogether.

### Commit 4: Bump vFXT version to 0.5.5.2
- new changes -> new version (new me)

### Testing

Used this [pipeline](https://msazure.visualstudio.com/One/_build/results?buildId=65913015&view=results) to create the image version [20221214.50341.24](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/a44e8215-d744-4fdf-8b42-59fb33c1a0fe/resourceGroups/vfxtcontroller-pipelines-sig/providers/Microsoft.Compute/galleries/vfxtcontroller_pipelines_sig/images/controller-builds/versions/20221214.50341.24/overview).

#### Scenarios:

- manual: `--from-environment`
- manual: using `--application-id`, `--application-secret`, `--subscription-id`, and `--tenant-id`
- manual AND automated: using `--on-instance` - passing [ARM vFXT pipeline](https://dev.azure.com/averevfxt/vfxt-github/_build/results?buildId=10514&view=results)