### PR TITLE
vFXT/msazure.py: change VM operation 'deallocate' to 'begin_deallocate'

### DIFF
--- a/vFXT/msazure.py
+++ b/vFXT/msazure.py
@@ -939,8 +939,8 @@ class Service(ServiceBase):
         retries = self.CLOUD_API_RETRIES
         while True:
             try:
-                # use deallocate (instead of stop) so that we do not get charged for the vm
-                op = conn.virtual_machines.deallocate(self._instance_resource_group(instance), self.name(instance))
+                # use begin_deallocate (instead of stop) so that we do not get charged for the vm
+                op = conn.virtual_machines.begin_deallocate(self._instance_resource_group(instance), self.name(instance))
                 break
             except msrestazure.azure_exceptions.CloudError:
                 if retries == 0:

--- a/vFXT/version.py
+++ b/vFXT/version.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2020 Avere Systems, Inc.  All Rights Reserved.
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE in the project root for license information.
-__version__ = "0.5.5.1"
-__version_info__ = (0, 5, 5, 1)
+__version__ = "0.5.5.2"
+__version_info__ = (0, 5, 5, 2)


### PR DESCRIPTION
[ICM](https://portal.microsofticm.com/imp/v3/incidents/details/363780045/home)

Looks like the underlying call changed. [Relevant documentation](https://learn.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v2019_03_01.operations.virtualmachinesoperations?view=azure-python#deallocate-resource-group-name--vm-name--custom-headers-none--raw-false--polling-true----operation-config-)

How this got missed:

It looked like vfxt.py destroy worked fine because, when a deploy failed, the cluster and all associated resources would be deleted without issue. When the regular `vfxt.py destroy` command is run, it deallocates the nodes first (???) and then deletes them. The underlying call changed from `VirtualMachineOperations.deallocate` to `VirtualMachineOperations.begin_deallocate`. The same change was made to `VirtualMachineOperations.delete` (swapped to `begin_delete` but it looks like someone who came before me made that change.

**TLDR: (almost) no one uses this**

Testing:
1. tested manually in a venv on : 
- pushed up this fix
- used the portal to spin up a controller; on the controller, made a virtual env; installed dependencies; installed vfxt.py from the repo on my test branch
- on the controller, ran 
`vfxt.py --from-environment --resource-group "$RG" --network-resource-group "$RG" --location "$LOCATION" --azure-network "$VNET" --azure-subnet "$SUBNET" --create --cluster-name "$CLUSTER" --admin-password "redacted" --instance-type "$TYPE" --node-cache-size "$NODE_CACHE" --azure-role "$ROLE" --storage-account "$STORAGE" --log "$LOG" --nodes "$NODES" --debug`
- grabbed the management address from the output
- fed it into the following
`vfxt.py --from-environment --instance-type "$TYPE" --node-cache-size "$NODE_CACHE" --azure-role "$ROLE" --debug --resource-group "$RG" --location "$LOCATION"  --network-resource-group "$RG" --azure-network "$VNET" --azure-subnet "$SUBNET" --cluster-name "$CLUSTER" --admin-password "redacted" --destroy --management-address $MANAGEMENT_ADDRESS`

2. made a [controller sig image-version](https://msazure.visualstudio.com/One/_build/results?buildId=67919779&view=results) using my averesdk test branch; fed that into the [arm vfxt pipeline](https://dev.azure.com/averevfxt/vfxt-github/_build/results?buildId=10609&view=results) 

3. also used that image to make a controller manually to run create/destroy on them (see commands in 1)