### PR TITLE
Fixing name for averecmd

### DIFF
--- a/controller/install.sh
+++ b/controller/install.sh
@@ -95,7 +95,7 @@ curl -f -L -o /armscripts/create-cloudbacked-cluster https://raw.githubuserconte
 curl -f -L -o /armscripts/create-minimal-cluster https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/create-minimal-cluster
 curl -f -L -o /armscripts/destroy-cluster https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/destroy-cluster
 curl -f -L -o /armscripts/VFXT_README https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/VFXT_README
-curl -f -L -o /usr/local/bin/averecmd.py https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/averecmd.py
+curl -f -L -o /usr/local/bin/averecmd https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/averecmd.py
 curl -f -L -o /opt/avere/installvfxt.sh https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/installvfxt.sh
 curl -f -L -o /opt/avere/enablecloudtrace.sh https://raw.githubusercontent.com/${REPO}/${BRANCH}/controller/armscripts/enablecloudtrace.sh
 
@@ -105,6 +105,6 @@ chmod 755 /armscripts/add-nodes
 chmod 755 /armscripts/create-cloudbacked-cluster
 chmod 755 /armscripts/create-minimal-cluster
 chmod 755 /armscripts/destroy-cluster
-chmod 755 /usr/local/bin/averecmd.py
+chmod 755 /usr/local/bin/averecmd
 chmod 755 /opt/avere/installvfxt.sh
 chmod 755 /opt/avere/enablecloudtrace.sh


### PR DESCRIPTION
Other modules expect the name to be averecmd.